### PR TITLE
Add support for .adoc, .asciidoc extensions, make .adoc the default extension

### DIFF
--- a/AsciiDoc.tmLanguage
+++ b/AsciiDoc.tmLanguage
@@ -9,6 +9,8 @@
 	</string>
 	<key>fileTypes</key>
 	<array>
+		<string>adoc</string>
+		<string>asciidoc</string>
 		<string>asc</string>
 	</array>
 	<key>foldingStartMarker</key>


### PR DESCRIPTION
This pull request is similar to gAmUssA's request, but it:
    \* also adds support for the .asciidoc extension, which is used by O'Reilly, and 
    \* it also makes .adoc the default extension. 

The .adoc extension is preferred over .asc. Dan Allen of Asciidoctor fame is trying to deprecate use of the .asc extension for AsciiDoc because it's also commonly used for GPG keys.

This request won't break gAmUssA's, so I went ahead and submitted it as a separate request.
