### PR TITLE
Update AsciiDoc.tmLanguage to add `.asciidoc` to the list of supported extensions

### DIFF
--- a/AsciiDoc.tmLanguage
+++ b/AsciiDoc.tmLanguage
@@ -10,6 +10,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>asc</string>
+		<string>asciidoc</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>(?x)


### PR DESCRIPTION
Added `.asciidoc` extension.
