### PR TITLE
Fix spelling in raw scopes

### DIFF
--- a/AsciiDoc.tmLanguage
+++ b/AsciiDoc.tmLanguage
@@ -561,14 +561,14 @@
 					<key>name</key>
 					<string>punctuation.definition.raw.asciidoc</string>
 				</dict>
-				<key>3</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.raw.asciidoc</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(`+)([^`]|(?!(?&lt;!`)\1(?!`))`)*+(\1)</string>
+			<string>(`+)(?:[^`]|(?!(?&lt;!`)\1(?!`))`)*+(\1)</string>
 			<key>name</key>
 			<string>markup.raw.inline.asciidoc</string>
 		</dict>


### PR DESCRIPTION
Previously the contents of a raw scope included an unused capture group (2) that caused the contents to be tokenized into multiple tokens, which prevented the spell checker from being run on the whole last word.

For instance ``Test`` would be tokenized to `Tes` and `t`. This is because the final `t` was captured by group 2. Since captures are normally used to apply different scope names, it had to be split into its own token.

By converting it to a non-capturing group (since it isn't used in `captures`), the whole contents of the raw section can be tokenized properly and then spell-checked properly.
